### PR TITLE
Feature/issue 3

### DIFF
--- a/.idea/.idea.HumbleKeysLibrary/.idea/.gitignore
+++ b/.idea/.idea.HumbleKeysLibrary/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/.idea.HumbleKeysLibrary.iml
+/modules.xml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.HumbleKeysLibrary/.idea/encodings.xml
+++ b/.idea/.idea.HumbleKeysLibrary/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.HumbleKeysLibrary/.idea/indexLayout.xml
+++ b/.idea/.idea.HumbleKeysLibrary/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.HumbleKeysLibrary/.idea/vcs.xml
+++ b/.idea/.idea.HumbleKeysLibrary/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.run/Toolbox pack.run.xml
+++ b/.run/Toolbox pack.run.xml
@@ -1,0 +1,12 @@
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Toolbox pack" type="RunNativeExe" factoryName="Native Executable" activateToolWindowBeforeRun="false">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/../../Games/Playnite/Toolbox.exe" />
+    <option name="PROGRAM_PARAMETERS" value="pack x:\git\HumbleKeysLibrary\bin\release x:\git\HumbleKeysLibrary\publish" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/bin/Release" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <method v="2">
+      <option name="Build" default="false" projectName="HumbleKeysLibrary" projectPath="file://$PROJECT_DIR$/HumbleKeysLibrary.csproj" />
+    </method>
+  </configuration>
+</component>

--- a/HumbleKeysLibrary.cs
+++ b/HumbleKeysLibrary.cs
@@ -3,6 +3,7 @@ using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows.Controls;
 using HumbleKeys.Models;
@@ -17,6 +18,8 @@ namespace HumbleKeys
         private static readonly ILogger logger = LogManager.GetLogger();
         private const string dbImportMessageId = "humblekeyslibImportError";
         private const string humblePurchaseUrlMask = @"https://www.humblebundle.com/downloads?key={0}";
+        const string steamGameUrlMask = @"https://store.steampowered.com/app/{0}";
+        const string steamSearchUrlMask = @"https://store.steampowered.com/search/?term={0}";
         private const string REDEEMED_STR = "Key: Redeemed";
         private const string UNREDEEMED_STR = "Key: Unredeemed";
         private static readonly string[] PAST_TAGS = { REDEEMED_STR, UNREDEEMED_STR, "Redeemed", "Unredeemed", };
@@ -51,7 +54,6 @@ namespace HumbleKeys
         }
 
         public override IEnumerable<Game> ImportGames(LibraryImportGamesArgs args)
-
         {
             var importedGames = new List<Game>();
             Exception importError = null;
@@ -114,10 +116,8 @@ namespace HumbleKeys
                 .Where(t => t != null
                             && Settings.keyTypeWhitelist.Contains(t.key_type)
                             && !string.IsNullOrWhiteSpace(t.gamekey)
-                            && !(Settings.IgnoreRedeemedKeys && IsKeyPresent(t))
                 ).GroupBy(tpk => tpk.gamekey);
         }
-
 
         protected void TpkdsIntake(Dictionary<string,Order> orders, IEnumerable<IGrouping<string, Order.TpkdDict.Tpk>> tpkds, ref List<Game> importedGames)
         {
@@ -141,18 +141,94 @@ namespace HumbleKeys
 
                     var alreadyImported = 
                         PlayniteApi.Database.Games.FirstOrDefault(
-                            g => g.GameId == GetGameId(tpkd) && g.PluginId == Id);
+                            game => game.GameId == GetGameId(tpkd) && game.PluginId == Id);
 
                     if (alreadyImported == null)
                     {
-                        importedGames.Add(ImportNewGame(tpkd, groupTag));
+                        if (!Settings.IgnoreRedeemedKeys || (Settings.IgnoreRedeemedKeys && !IsKeyPresent(tpkd)))
+                        {
+                            importedGames.Add(ImportNewGame(tpkd, groupTag));
+                        }
                     }
                     else
                     {
-                        UpdateExistingGame(alreadyImported, tpkd, groupTag);
+                        if (!Settings.IgnoreRedeemedKeys || (Settings.IgnoreRedeemedKeys && !IsKeyPresent(tpkd)))
+                        {
+                            var tagsUpdated = UpdateRedemptionStatus(alreadyImported, tpkd, groupTag);
+                            var linksUpdated = UpdateStoreLinks(alreadyImported.Links, tpkd);
+                            if (!tagsUpdated && !linksUpdated) continue;
+                            
+                            PlayniteApi.Database.BeginBufferUpdate();
+                            PlayniteApi.Database.Games.Update(alreadyImported);
+                            PlayniteApi.Database.EndBufferUpdate();
+                            PlayniteApi.Notifications.Add(
+                                new NotificationMessage("HumbleKeysLibraryUpdate",
+                                    $"Tags Updated for {alreadyImported.Name}", NotificationType.Info,
+                                    () =>
+                                    {
+                                        if (PlayniteApi.ApplicationInfo.Mode == ApplicationMode.Fullscreen) return;
+                                        PlayniteApi.MainView.SelectGame(alreadyImported.Id);
+                                    })
+                            );
+                        }
+                        else
+                        {
+                            // Remove Existing Game?
+                            PlayniteApi.Database.Games.Remove(alreadyImported);
+                            logger.Trace(
+                                $"Removing game {alreadyImported.Name} since Settings.IgnoreRedeemedKeys is: [{Settings.IgnoreRedeemedKeys}] and IsKeyPresent() is [{IsKeyPresent(tpkd)}]");
+                        }
                     }
                 }
             }
+        }
+
+        bool UpdateStoreLinks(ObservableCollection<Link> links, Order.TpkdDict.Tpk tpkd)
+        {
+            if (tpkd.key_type != "steam") return false;
+
+            Link steamGameLink;
+            string humanName = string.Empty;
+            if (!string.IsNullOrEmpty(tpkd.steam_app_id))
+            {
+                steamGameLink = MakeSteamLink(tpkd.steam_app_id);
+            }
+            else
+            {
+                humanName = tpkd.human_name;
+                steamGameLink = new Link("Steam", string.Format(steamSearchUrlMask, humanName.Replace(" ", "%2B")));
+            }
+
+            if (humanName.EndsWith(" Steam"))
+            {
+                humanName = humanName.Remove(humanName.LastIndexOf(" Steam", StringComparison.Ordinal));
+            }
+            if (humanName.EndsWith(" DLC"))
+            {
+                humanName = humanName.Remove(humanName.LastIndexOf(" DLC", StringComparison.Ordinal));
+            }
+            var steamLinks = links.Where((link1, i) => link1.Name == "Steam");
+            var steamLinksList = steamLinks.ToList();
+            var existingSteamLink = steamLinksList.FirstOrDefault();
+            if (existingSteamLink == null)
+            {
+                links.Add(steamGameLink);
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(tpkd.steam_app_id) && existingSteamLink.Url == steamGameLink.Url) return false;
+
+            // steam link url doesn't match expected value
+            if (existingSteamLink.Url != steamGameLink.Url)
+            {
+                existingSteamLink.Url = steamGameLink.Url;
+            }
+            else
+            {
+                return false;
+            }
+
+            return true;
         }
 
         Game ImportNewGame(Order.TpkdDict.Tpk tpkd, Tag groupTag = null)
@@ -168,46 +244,69 @@ namespace HumbleKeys
                 Links = new List<Link>(),
             };
             
+            // add tag reflecting redemption status
             gameInfo.Tags.Add(new MetadataNameProperty(GetRedeemedTag(tpkd)));
+            
             if (!string.IsNullOrWhiteSpace(tpkd?.gamekey))
             {
                 gameInfo.Links.Add(MakeLink(tpkd?.gamekey));
+            }
+            // adds link to humble purchase
+            var links = new ObservableCollection<Link>();
+            if (UpdateStoreLinks(links, tpkd))
+            {
+                gameInfo.Links.AddRange(links.ToList());
             }
             PlayniteApi.Database.BeginBufferUpdate();
             var game = PlayniteApi.Database.ImportGame(gameInfo, this);
             if (groupTag != null)
             {
-                game.Tags.Add(groupTag);
+                game.TagIds.Add(groupTag.Id);
                 PlayniteApi.Database.Games.Update(game);
             }
             PlayniteApi.Database.EndBufferUpdate();
             return game;
         }
 
-        void UpdateExistingGame(Game existingGame, Order.TpkdDict.Tpk tpkd, Tag groupTag = null)
+        // If a game had been redeemed since last added to Playnite, remove the tag 'Key: Unredeemed' and add the tag 'Key: Redeemed'
+        // returns whether tags were updated or not 
+        bool UpdateRedemptionStatus(Game existingGame, Order.TpkdDict.Tpk tpkd, Tag groupTag = null)
         {
-            if (existingGame == null) { return; }
-            if (!Settings.keyTypeWhitelist.Contains(tpkd.key_type)) { return; }
+            var recordChanged = false;
+            if (existingGame == null) { return false; }
+            if (!Settings.keyTypeWhitelist.Contains(tpkd.key_type)) { return false; }
 
-            var existingTagIds = existingGame.Tags.Where(t => PAST_TAGS.Contains(t.Name)).Select(tag => tag.Id);
-            existingGame.TagIds.RemoveAll(tagId => existingTagIds.Contains(tagId));
+            // process tags on existingGame only if there was a change in tag status
+            
+            var existingRedemptionTagIds = existingGame.Tags?.Where(t => PAST_TAGS.Contains(t.Name)).Select(tag => tag.Id);
+            
+            // This creates a new Tag in the Tag Database if it doesn't already exist for 'Tag: Redeemed'
+            var redeemedTag = PlayniteApi.Database.Tags.Add(GetRedeemedTag(tpkd));
+            if (existingRedemptionTagIds == null) return false;
+            var tagIds = existingRedemptionTagIds.ToList();
 
-            PlayniteApi.Database.BeginBufferUpdate();
-            existingGame.TagIds.Add(PlayniteApi.Database.Tags.Add(IsKeyPresent(tpkd) ? REDEEMED_STR : UNREDEEMED_STR ).Id);
             if (groupTag != null)
             {
                 if (existingGame.Tags.All(tag => tag.Id != groupTag.Id))
                 {
                     existingGame.TagIds.Add(groupTag.Id);
+                    recordChanged = true;
                 }
             }
-            PlayniteApi.Database.Games.Update(existingGame);
-            PlayniteApi.Database.EndBufferUpdate();
+
+            if (tagIds.Contains(redeemedTag.Id)) return recordChanged;
+
+            existingGame.TagIds.RemoveAll(tagId => tagIds.Contains(tagId));
+            existingGame.TagIds.Add(
+                PlayniteApi.Database.Tags.Add(IsKeyPresent(tpkd) ? REDEEMED_STR : UNREDEEMED_STR).Id);
+            
+            return true;
         }
 
         #region === Helper Methods ============
         private static string GetGameId(Order.TpkdDict.Tpk tpk) => $"{tpk.machine_name}_{tpk.gamekey}";
-        private static Link MakeLink(string gamekey) => new Link("Humble Purchase URL", string.Format(humblePurchaseUrlMask, gamekey) );
+        private static Link MakeLink(string gameKey) => new Link("Humble Purchase URL", string.Format(humblePurchaseUrlMask, gameKey) );
+        private static Link MakeSteamLink(string gameKey) => new Link("Steam", string.Format(steamGameUrlMask, gameKey));
         private static bool IsKeyNull(Order.TpkdDict.Tpk t) => t?.redeemed_key_val == null;
         private static bool IsKeyPresent(Order.TpkdDict.Tpk t) => !IsKeyNull(t);
         private static string GetRedeemedTag(Order.TpkdDict.Tpk t) => IsKeyPresent(t) ? REDEEMED_STR : UNREDEEMED_STR;

--- a/HumbleKeysLibrary.csproj
+++ b/HumbleKeysLibrary.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>HumbleKeysLibrary</RootNamespace>
+    <RootNamespace>HumbleKeys</RootNamespace>
     <AssemblyName>HumbleKeysLibrary</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -36,9 +36,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=5.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\PlayniteSDK.6.2.2\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.9.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -61,9 +60,15 @@
     <Compile Include="HumbleKeysLibrarySettingsView.xaml.cs">
       <DependentUpon>HumbleKeysLibrarySettingsView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Models\ContentChoice.cs" />
+    <Compile Include="Models\ChoiceMonthV2.cs" />
+    <Compile Include="Models\ChoiceMonthV3.cs" />
+    <Compile Include="Models\IChoiceMonth.cs" />
     <Compile Include="Models\Order.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\HumbleKeysAccountClient.cs" />
+    <Compile Include="Services\HumbleKeysAccountClientSettings.cs" />
+    <Compile Include="Services\IHumbleKeysAccountClientSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/HumbleKeysLibrary.sln.DotSettings
+++ b/HumbleKeysLibrary.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playnite/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/HumbleKeysLibrary.sln.DotSettings
+++ b/HumbleKeysLibrary.sln.DotSettings
@@ -5,4 +5,6 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AA_BB" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gamekeys/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=humblebundle/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playnite/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/HumbleKeysLibrary.sln.DotSettings
+++ b/HumbleKeysLibrary.sln.DotSettings
@@ -1,2 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AA_BB" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AA_BB" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playnite/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/HumbleKeysLibrarySettings.cs
+++ b/HumbleKeysLibrarySettings.cs
@@ -1,11 +1,10 @@
-﻿using Newtonsoft.Json;
-using Playnite.SDK;
+﻿using Playnite.SDK;
 using HumbleKeys.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using HumbleKeys.Services;
-
+using Playnite.SDK.Data;
 
 namespace HumbleKeys
 {
@@ -17,7 +16,11 @@ namespace HumbleKeys
 
         public bool ConnectAccount { get; set; } = false;
         public bool IgnoreRedeemedKeys { get; set; } = false;
+        public bool ImportChoiceKeys { get; set; } = false;
+        public bool CacheEnabled { get; set; } = false;
+        public string CurrentTagMethodology { get; set; } = "none";
 
+        [DontSerialize]
         public List<string> keyTypeWhitelist = new List<string>() {
             "gog",
             "nintendo_direct",
@@ -26,7 +29,7 @@ namespace HumbleKeys
             "steam",
         };
 
-        [JsonIgnore]
+        [DontSerialize]
         public bool IsUserLoggedIn
         {
             get
@@ -43,7 +46,7 @@ namespace HumbleKeys
             }
         }
 
-        [JsonIgnore]
+        [DontSerialize]
         public RelayCommand<object> LoginCommand
         {
             get => new RelayCommand<object>((a) =>

--- a/HumbleKeysLibrarySettingsView.xaml
+++ b/HumbleKeysLibrarySettingsView.xaml
@@ -31,11 +31,37 @@
 					IsEnabled="{Binding IsChecked, ElementName=CheckHumbleConnectAccount}">
 
 			<CheckBox Margin="0,10,0,0"
-							IsChecked="{Binding IgnoreRedeemedKeys}"
-							Content="Ignore Redeemed Keys"
-							ToolTip="When checked, Humble Keys Library does not import keys that have already been redeemed."/>
-
-
+			          IsChecked="{Binding IgnoreRedeemedKeys}"
+			          Content="Ignore Redeemed Keys"
+			          ToolTip="When checked, Humble Keys Library does not import keys that have already been redeemed."/>
+			<CheckBox Margin="0,10,0,0"
+			          IsChecked="{Binding ImportChoiceKeys}"
+			          Content="Import Choice Games"
+			          Name="ImportChoiceKeys"
+			          ToolTip="When checked, Humble Keys Library will import Humble Choice games for months that the User is subscribed for." Unchecked="ImportChoiceKeys_OnUnchecked"/>
+			<StackPanel Margin="0 10 0 10" Width="Auto" Orientation="Horizontal">
+				<Grid Width="Auto">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"></ColumnDefinition>
+						<ColumnDefinition Width="Auto"></ColumnDefinition>
+					</Grid.ColumnDefinitions>
+					<TextBlock
+				          Name="TagWithBundleName"
+				          Text="Create Tags for Bundle Names"
+				          ToolTip="When None is not selected, Humble Keys Library will add a new Tag per Bundle Name"
+				          Grid.Column="0"/>
+					<ListBox Margin="10 0 0 0 " Name="TagMethodology" SelectedValuePath="Tag" SelectedValue="{Binding CurrentTagMethodology, Mode=TwoWay}" Grid.Column="1" SelectionMode="Single">
+						<ListBoxItem Tag="none" ToolTip="Do not create Tags based on Bundle Name">None</ListBoxItem>
+						<ListBoxItem Tag="monthly" ToolTip="Create only Tags for Humble Choice Monthly bundles" IsEnabled="{Binding IsChecked,ElementName=ImportChoiceKeys}">Monthly Only</ListBoxItem>
+						<ListBoxItem Tag="all" ToolTip="Create Tags for all Bundles">All</ListBoxItem>
+					</ListBox>
+				</Grid>
+			</StackPanel>
+			<CheckBox Margin="0,10,0,0"
+			          IsChecked="{Binding CacheEnabled}"
+			          Content="Enable Cache"
+			          Name="EnableCache"
+			          ToolTip="When checked, Humble Keys Library will create a persistent Cache in ExtensionsData directory, if a Cache entry exists, it will no longer be retrieved from Humble"/>
 			<StackPanel Orientation="Horizontal" Margin="0,10,0,0">
 				<!--<Button Content="{DynamicResource LOCAuthenticateLabel}" HorizontalAlignment="Left"
 						Command="{Binding LoginCommand}" Margin="0,5,5,5"/>-->

--- a/HumbleKeysLibrarySettingsView.xaml
+++ b/HumbleKeysLibrarySettingsView.xaml
@@ -33,7 +33,7 @@
 			<CheckBox Margin="0,10,0,0"
 			          IsChecked="{Binding IgnoreRedeemedKeys}"
 			          Content="Ignore Redeemed Keys"
-			          ToolTip="When checked, Humble Keys Library does not import keys that have already been redeemed."/>
+			          ToolTip="When checked, Humble Keys Library does not import keys that have already been redeemed. (NOTE: Unchecking this and running a library sync will REMOVE prior imported games that have been redeemed)"/>
 			<CheckBox Margin="0,10,0,0"
 			          IsChecked="{Binding ImportChoiceKeys}"
 			          Content="Import Choice Games"

--- a/HumbleKeysLibrarySettingsView.xaml.cs
+++ b/HumbleKeysLibrarySettingsView.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace HumbleKeys
 {
@@ -20,6 +8,18 @@ namespace HumbleKeys
         public HumbleKeysLibrarySettingsView()
         {
             InitializeComponent();
+        }
+
+        void ImportChoiceKeys_OnUnchecked(object sender, RoutedEventArgs e)
+        {
+            if (!(DataContext is HumbleKeysLibrarySettings model)) return;
+            if (model.CurrentTagMethodology != "monthly") return;
+            model.CurrentTagMethodology = "none";
+            if (!(FindName("TagMethodology") is ListBox listBox)) return;
+            foreach (ListBoxItem listBoxItem in listBox.Items)
+            {
+                listBoxItem.IsSelected = (string)listBoxItem.Tag == model.CurrentTagMethodology;
+            }
         }
     }
 }

--- a/Models/ChoiceMonthV2.cs
+++ b/Models/ChoiceMonthV2.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Playnite.SDK.Data;
+
+namespace HumbleKeys.Models
+{
+    public class ChoiceMonthV2 : IChoiceMonth
+    {
+        public class ContentChoiceOptions
+        {
+            public class ContentChoiceDataContainer
+            {
+                public class ContentChoiceData
+                {
+                    public Dictionary<string, ContentChoice> content_choices;
+                }
+                [SerializationPropertyName("initial")]
+                public ContentChoiceData initial;
+                [SerializationPropertyName("initial-get-all-games")]
+                public ContentChoiceData initialGetAllGames;
+            }
+
+            public string gamekey { get; }
+
+            public string title { get; }
+
+            public ContentChoiceDataContainer contentChoiceData;
+        }
+
+        public ContentChoiceOptions contentChoiceOptions;
+
+        public string GameKey => contentChoiceOptions.gamekey;
+
+        public string Title => contentChoiceOptions.title;
+        public List<ContentChoice> ContentChoices => contentChoiceOptions.contentChoiceData.initial?.content_choices.Values.ToList()??contentChoiceOptions.contentChoiceData.initialGetAllGames.content_choices.Values.ToList();
+    }
+}

--- a/Models/ChoiceMonthV3.cs
+++ b/Models/ChoiceMonthV3.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace HumbleKeys.Models
+{
+    public class ChoiceMonthV3 : IChoiceMonth
+    {
+        public class ContentChoiceOptions
+        {
+            public class ContentChoiceDataContainer
+            {
+                
+                public Dictionary<string,ContentChoice> game_data;
+            }
+
+            public string gamekey { get; }
+
+            public string title { get; }
+            
+            public ContentChoiceDataContainer contentChoiceData;
+        }
+
+        public ContentChoiceOptions contentChoiceOptions;
+        public string GameKey => contentChoiceOptions.gamekey;
+        public string Title => contentChoiceOptions.title;
+        public List<ContentChoice> ContentChoices => contentChoiceOptions.contentChoiceData.game_data.Values.ToList();
+    }
+}

--- a/Models/ContentChoice.cs
+++ b/Models/ContentChoice.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Playnite.SDK.Data;
+
+namespace HumbleKeys.Models
+{
+    public class ContentChoice
+    {
+        [SerializationPropertyName("title")]
+        public string Title;
+        public Order.TpkdDict.Tpk[] tpkds;
+        public Dictionary<string, Order.TpkdDict.Tpk[]> nested_choice_tpkds;
+    }
+}

--- a/Models/IChoiceMonth.cs
+++ b/Models/IChoiceMonth.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace HumbleKeys.Models
+{
+    public interface IChoiceMonth
+    {
+        string GameKey { get; }
+        string Title { get; }
+        List<ContentChoice> ContentChoices { get; }
+    }
+}

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -10,6 +10,9 @@ namespace HumbleKeys.Models
             public string category;
             public string machine_name;
             public string human_name;
+            public string choice_url;
+            public bool is_subs_v2_product;
+            public bool is_subs_v3_product;
         }
 
         public class SubProduct

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -62,6 +62,8 @@ namespace HumbleKeys.Models
                 public string human_name;
                 public string @class;
                 public string library_family_name;
+                public string steam_app_id;
+                public bool is_expired;
                 public Newtonsoft.Json.Linq.JToken redeemed_key_val;
             }
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@ The default Humble Library plug-in only reports DRM-free games, not the keys for
 2. Drag-and-drop the .pext file onto your Playnite window.
 
 ## Settings
-`Ignore Redeemed Keys` is a setting added in v0.1.4. When checked, HumbleKeysLibrary will not import keys that have been revealed on the Humble site.
+* `Ignore Redeemed Keys` is a setting added in v0.1.4. When checked, HumbleKeysLibrary will not import keys that have been revealed on the Humble site.
+* `Import Choice Games` is a setting added in v.0.1.5. When checked, purchases that are detected as Humble Choice Bundles will have the bundle's individual games added.
+* `Create Tags for Bundle Names` is a setting added in v.0.1.5. When an entry not `None` is selected, it will create a tag in the format of `Bundle: [Bundle Name]`
+* `Enable Cache` is a setting added in v.0.1.5. When checked, HumbleKeysLibrary will create json files for data retrieved from the Humble API in the ExtensionsData directory. If a Cache file exists, the API will not be queried. This applies to Purchases, Memberships (Humble Monthly) and Orders.
 
 ## Details
 ### Tags
 * `Key: Redeemed` - this tag is attached to entries that have been redeemed. Corresponds to Humble API `tpkd_dict.all_tpks[n].redeemed_key_value`.
 * `Key: Unredeemed` - this tag is attached to entries that have not been redeemed. Corresponds to Humble API `tpkd_dict.all_tpks[n].redeemed_key_value`.
+* `Bundle: [Bundle Name]` - this tag is attached to entries that belong to a  Bundle. Corresponds to Humble API `order.product.human_name`
 
 ### Key Types
 Humble API lists key types in `tpkd_dict.all_tpks[n].key_type`, which corresponds to the services on which the key can be redeemed. Supported keys include:

--- a/Services/HumbleKeysAccountClient.cs
+++ b/Services/HumbleKeysAccountClient.cs
@@ -1,12 +1,11 @@
 ﻿using HumbleKeys.Models;
 using Playnite.SDK;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Linq;
-
+using Playnite.SDK.Data;
 
 namespace HumbleKeys.Services
 {
@@ -19,8 +18,46 @@ namespace HumbleKeys.Services
         private const string logoutUrl = @"https://www.humblebundle.com/logout?goto=/";
         private const string orderUrlMask = @"https://www.humblebundle.com/api/v1/order/{0}?all_tpkds=true";
 
+        const string SubscriptionCategory = @"subscriptioncontent";
+        readonly bool _preferCache;
+        readonly string _localCachePath;
+        readonly IHumbleKeysAccountClientSettings _clientSettings;
         public HumbleKeysAccountClient(IWebView webView) { this.webView = webView; }
+        
+        public HumbleKeysAccountClient(IWebView webView, IHumbleKeysAccountClientSettings clientSettings) : this(webView)
+        {
+            _localCachePath = Directory.Exists(clientSettings.CachePath) ? clientSettings.CachePath : new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName;
 
+            _preferCache = clientSettings.CacheEnabled;
+            // initialise folder structure for local cache
+            var cachePaths = new[] { "order", "membership" };
+            if (_preferCache)
+            {
+                foreach (var cachePath in cachePaths)
+                {
+                    if (!Directory.Exists($"{_localCachePath}\\{cachePath}"))
+                    {
+                        Directory.CreateDirectory($"{_localCachePath}\\{cachePath}");
+                    }
+                }
+            }
+            else
+            {
+                File.Delete($"{_localCachePath}\\gameKeys.json");
+                foreach (var cachePath in cachePaths)
+                {
+                    if (!Directory.Exists($"{_localCachePath}\\{cachePath}")) continue;
+                    
+                    var cachedFiles = Directory.EnumerateFiles($"{_localCachePath}\\{cachePath}");
+                    foreach (var cachedFile in cachedFiles)
+                    {
+                        File.Delete(cachedFile);
+                    }
+                    Directory.Delete($"{_localCachePath}\\{cachePath}");
+                }
+                logger.Info("Cache cleared");
+            }
+        }
 
         public void Login()
         {
@@ -49,65 +86,168 @@ namespace HumbleKeys.Services
 
         internal List<string> GetLibraryKeys()
         {
+            var keysCacheFilename = $"{_localCachePath}\\gamekeys.json";
+            if (_preferCache)
+            {
+                // Request may be cached in local filesystem to prevent spamming Humble
+                var cachedData = GetCacheContent<List<string>>(keysCacheFilename);
+                if (cachedData != null)
+                {
+                    return cachedData;
+                }
+            }
+
             webView.NavigateAndWait(libraryUrl);
-            var libSource = webView.GetPageSource();
-            var match = Regex.Match(libSource, @"""gamekeys"":\s*(\[.+\])");
-            if (match.Success)
-            {
+                var libSource = webView.GetPageSource();
+                var match = Regex.Match(libSource, @"""gamekeys"":\s*(\[.+\])");
+                if (!match.Success) throw new Exception("User is not authenticated.");
+                
                 var strKeys = match.Groups[1].Value;
-                return FromJson<List<string>>(strKeys);
-            }
-            else
-            {
-                throw new Exception("User is not authenticated.");
-            }
+                logger.Trace(
+                    $"Request:{libraryUrl} Content:{Serialization.ToJson(Serialization.FromJson<List<string>>(strKeys), true)}");
+                if (_preferCache)
+                {
+                    CreateCacheContent(keysCacheFilename,strKeys);
+                }
+                return Serialization.FromJson<List<string>>(strKeys);
+
         }
 
-
-        internal List<Order> GetOrders(List<string> gamekeys)
+        string GetCacheContent(string keysCacheFilename)
         {
-            var orders = new List<Order>();
-            foreach (var key in gamekeys)
-            {
-                webView.NavigateAndWait(string.Format(orderUrlMask, key));
-                var strContent = webView.GetPageText();
+            if (!File.Exists(keysCacheFilename)) return null;
+            var streamReader = new StreamReader(new FileStream(keysCacheFilename, FileMode.Open));
+            var cacheContent = streamReader.ReadToEnd();
+            streamReader.Close();
+            return cacheContent;
+        }
+        T GetCacheContent<T>(string keysCacheFilename) where T : class
+        {
+            var cacheContent = GetCacheContent(keysCacheFilename);
+            return cacheContent == null ? null : Serialization.FromJson<T>(cacheContent);
+        }
 
-                orders.Add(FromJson<Order>(strContent));
+        void CreateCacheContent(string cacheFilename, string strCacheEntry)
+        {
+            var streamWriter = new StreamWriter(new FileStream(cacheFilename, FileMode.OpenOrCreate));
+            streamWriter.Write(strCacheEntry);
+            streamWriter.Close();
+        }
+        
+        internal Dictionary<string, Order> GetOrders(List<string> gameKeys, bool includeChoiceMonths = false)
+        {
+            var orders = new Dictionary<string, Order>();
+            foreach (var key in gameKeys)
+            {
+                var orderUri = string.Format(orderUrlMask, key);
+                var cacheFileName = $"{_localCachePath}/order/{key}.json";
+                Order order = null;
+                if (_preferCache)
+                {
+                    order = GetCacheContent<Order>(cacheFileName);
+                }
+                if (order == null) {
+                    webView.NavigateAndWait(orderUri);
+                    var strContent = webView.GetPageText();
+                    if (_preferCache)
+                    {
+                        CreateCacheContent(cacheFileName,strContent);
+                    }
+                    order = Serialization.FromJson<Order>(strContent);
+                }
+                logger.Trace($"Request:{orderUri} Content:{Serialization.ToJson(order, true)}");
+
+                if (string.Equals(order.product.category, SubscriptionCategory, StringComparison.Ordinal) && !string.IsNullOrEmpty(order.product.choice_url) && includeChoiceMonths)
+                {
+                    AddChoiceMonthlyGames(order);
+                }
+                orders.Add(order.gamekey, order);
             }
 
             return orders;
         }
 
+        void AddChoiceMonthlyGames(Order order)
+        {
+            var cachePath = $"membership/{order.product.choice_url}";
+            var choiceUrl = $"https://www.humblebundle.com/{cachePath}";
+            var strChoiceMonth = string.Empty;
+            var orderCacheFilename = $"{_localCachePath}/{cachePath}.json";
+            if (_preferCache)
+            {
+                // Request may be cached in local filesystem to prevent spamming Humble
+                strChoiceMonth = GetCacheContent(orderCacheFilename);
+            }
+
+            if (string.IsNullOrEmpty(strChoiceMonth))
+            {
+                webView.NavigateAndWait(choiceUrl);
+                var match = Regex.Match(webView.GetPageSource(),
+                    @"<script id=""webpack-monthly-product-data"" type=""application/json"">([\s\S]*?)</script>");
+                if (match.Success)
+                {
+                    strChoiceMonth = match.Groups[1].Value;
+                    if (_preferCache)
+                    {
+                        // save data into cache
+                        CreateCacheContent(orderCacheFilename, strChoiceMonth);
+                    }
+                }
+                else
+                {
+                    logger.Error($"Unable to obtain Choice Monthly data for entry [{order.product.choice_url}]");
+                }
+            }
+
+            if (string.IsNullOrEmpty(strChoiceMonth)) return;
+            
+            IChoiceMonth choiceMonth = null;
+            if (order.product.is_subs_v2_product)
+            {
+                choiceMonth = Serialization.FromJson<ChoiceMonthV2>(strChoiceMonth);
+                logger.Trace($"Request:{choiceUrl} Content:{Serialization.ToJson(choiceMonth, true)}");
+            }
+            else if (order.product.is_subs_v3_product)
+            {
+                choiceMonth = Serialization.FromJson<ChoiceMonthV3>(strChoiceMonth);
+                logger.Trace($"Request:{choiceUrl} Content:{Serialization.ToJson(choiceMonth, true)}");
+            }
+            else
+            {
+                logger.Error("Unknown Choice Monthly product version");
+            }
+
+            if (choiceMonth == null) return;
+                
+            foreach (var contentChoice in choiceMonth.ContentChoices)
+            {
+                if (contentChoice.tpkds != null)
+                {
+                    order.tpkd_dict.all_tpks.AddRange(contentChoice.tpkds);
+                }
+                else if (contentChoice.nested_choice_tpkds != null)
+                {
+                    foreach (var nestedChoiceTpkd in contentChoice.nested_choice_tpkds)
+                    {
+                        order.tpkd_dict.all_tpks.AddRange(nestedChoiceTpkd.Value);
+                    }
+                }
+                else
+                {
+                    logger.Error($"Unable to retrieve tpkds for Choice Month Title:{choiceMonth.Title}");
+                }
+            }
+        }
 
         internal List<Order> GetOrders(string cachePath)
         {
             var orders = new List<Order>();
             foreach (var cacheFile in Directory.GetFiles(cachePath))
             {
-                orders.Add(FromJsonFile<Order>(cacheFile));
+                orders.Add(Serialization.FromJsonFile<Order>(cacheFile));
             }
 
             return orders;
         }
-
-
-        #region === Helper Methods ================
-        public static T FromJson<T>(string json) where T : class
-        {
-            try
-            {
-                return JsonConvert.DeserializeObject<T>(json);
-            }
-            catch
-            {
-                throw;
-            }
-        }
-
-        public static T FromJsonFile<T>(string filePath) where T : class
-        {
-            return FromJson<T>(File.ReadAllText(filePath));
-        }
-        #endregion
     }
 }

--- a/Services/HumbleKeysAccountClientSettings.cs
+++ b/Services/HumbleKeysAccountClientSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace HumbleKeys.Services
+{
+    public class HumbleKeysAccountClientSettings : IHumbleKeysAccountClientSettings
+    {
+        public bool CacheEnabled { get; set; }
+        public string CachePath { get; set; }
+    }
+}

--- a/Services/IHumbleKeysAccountClientSettings.cs
+++ b/Services/IHumbleKeysAccountClientSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace HumbleKeys.Services
+{
+    public interface IHumbleKeysAccountClientSettings
+    {
+        bool CacheEnabled { get; set; }
+        string CachePath { get; set; }
+    }
+}

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,10 +1,10 @@
 ﻿Name: Humble Keys Library Importer
-Author: Fierce Punch Studios
+Author: ecenshu
 Id: 62ac4052-e08a-4a1a-b70a-c2c0c3673bb9
-Version: 0.2.0
+Version: 0.2.1
 Module: HumbleKeysLibrary.dll
 Type: GameLibrary
 Icon: icon.png
 Links:
     - Name: GitHub
-      Url: https://github.com/FiercePunchStudios/HumbleKeysLibrary/
+      Url: https://github.com/ecenshu/HumbleKeysLibrary/

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="PlayniteSDK" version="6.9.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
-  <!--<package id="PlayniteSDK" version="5.2.0" targetFramework="net462" />-->
-  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
-
 </packages>


### PR DESCRIPTION
Only update database if current scan detected a change in the state of the entry
Allow for option of ignoring redeemed keys
Attempt to update Steam store link and generate link to humble store purchase when entry detected
