### PR TITLE
Restore plugin name and fix changelog

### DIFF
--- a/Manifests/HumbleKeysLibrary_AddonDB.yaml
+++ b/Manifests/HumbleKeysLibrary_AddonDB.yaml
@@ -5,8 +5,9 @@ InstallerManifestUrl: https://raw.githubusercontent.com/Dasmius007/HumbleKeysLib
 ShortDescription: Imports and tags game keys from Humble for user sorting purposes (supports Humble Choice too).
 Description: |
   Humble Keys Library is a library plug-in extension for Playnite which queries Humble Bundle for third-party keys, and also supports Humble Choice subscription games.
+
   The default Humble Library plug-in only reports DRM-free games, not the keys for third-party services like Steam. Humble Keys Library allows you to search your entire collection for a game, to make sure you don't buy a new copy in the latest sale if you already have one from a previous Humble Bundle.
-Name: Humble Keys
+Name: Humble Keys Library
 Author: Dasmius007
 Links:
   Playnite Forums thread: https://playnite.link/forum/thread-1244.html

--- a/changelog.md
+++ b/changelog.md
@@ -1,29 +1,28 @@
 ﻿## What's Changed
-# 0.3.6
-* Added support for multiple languages (currently only English is implemented, but other languages can now be added)
-* Language is determined by Windows culture (may add a setting for it later)
-* Fixed missing "Connect account" description next to checkbox
-* Fixed missing "Authenticate" button text
-* Now shows authentication status next to the button like other library add-ons
+# 0.3.7
+- Added support for multiple languages (currently only English is implemented, but other languages can now be added)
+- Language is determined by Windows culture (may add a setting for it later)
+- Fixed missing "Connect account" description next to checkbox
+- Fixed missing "Authenticate" button text
+- Now shows authentication status next to the button like other library add-ons
 
 # 0.3.4
-* Altered how tags are handled to deal with scenario where tags get removed manually via Manage Library function of Playnite
-* Corrected tooltips for Unredeemable key handling
-* Remove prerequisite "Import Choice Game" from "Unredeemable key handling" options
-* Correct github action to build against correct tag version
-* Update ChoiceMonth model to include ChoicesRemaining and ChoicesMade
-* Update Order model to determine virtual orders (items added from Bundle instead of from persisted record on server)
-* Alter HumbleKeysAccountClient to add virtual orders that have not yet been added to the Order
-* Add additional logic to HumbleKeysLibrary to handle unredeemable virtual orders (either expired and cannot be redeemed or part of a Bundle where all choices have been made)
-* Add new option to allow for either tagging a Game as "Key: Unredeemable" or not add to the library
-* Correct version number to match release version
-* Added Optional feature to import games in Humble Choice Monthly bundles.
-* Added Optional feature to create tags based on Bundle Names (Either all Bundles or Monthly only)
-* Added Optional feature to cache API Objects as JSON files in the ExtensionsData directory
+- Altered how tags are handled to deal with scenario where tags get removed manually via Manage Library function of Playnite
+- Corrected tooltips for Unredeemable key handling
+- Remove prerequisite "Import Choice Game" from "Unredeemable key handling" options
+- Correct github action to build against correct tag version
+- Update ChoiceMonth model to include ChoicesRemaining and ChoicesMade
+- Update Order model to determine virtual orders (items added from Bundle instead of from persisted record on server)
+- Alter HumbleKeysAccountClient to add virtual orders that have not yet been added to the Order
+- Add additional logic to HumbleKeysLibrary to handle unredeemable virtual orders (either expired and cannot be redeemed or part of a Bundle where all choices have been made)
+- Add new option to allow for either tagging a Game as "Key: Unredeemable" or not add to the library
+- Correct version number to match release version
+- Added Optional feature to import games in Humble Choice Monthly bundles.
+- Added Optional feature to create tags based on Bundle Names (Either all Bundles or Monthly only)
+- Added Optional feature to cache API Objects as JSON files in the ExtensionsData directory
 
 # 0.2.0
-Updated for new SDK. Also fixes Newtonsoft.Json exceptions thrown when Humble API returns **redeemed_key_val**
-as a JObject instead of JString.
+Updated for new SDK. Also fixes Newtonsoft.Json exceptions thrown when Humble API returns **redeemed_key_val** as a JObject instead of JString.
 
 Tested against:
 Playnite 9.18
@@ -31,8 +30,7 @@ SDK 6.2.2
 Desktop 2.1.0
 
 # 0.1.4
-Adds **Ignore Redeemed Keys** setting. When checked, the library does not import any keys which have
-already been redeemed.
+Adds **Ignore Redeemed Keys** setting. When checked, the library does not import any keys which have already been redeemed.
 
 # 0.1.3
 Compiled for Playnite 8.0
@@ -42,13 +40,10 @@ Removes references to Playnite and Playnite.Common assemblies to comply with SDK
 # 0.1.2
 Compiled for Playnite 7.9
 
-Improves key type filtering and adds settings view localization. Also changes "Platform" for keys to reflect the
-TPKD machine name, as the human names were too inconsistent and creating many single-game platforms.
+Improves key type filtering and adds settings view localization. Also changes "Platform" for keys to reflect the TPKD machine name, as the human names were too inconsistent and creating many single-game platforms.
 
 # 0.1.1
-Adds **nintendo_direct** tag to Humble key_type whitelist and removes extraneous **Humble Key: {key_type}** tagging,
-since that information is already in "Platform".
-
+Adds **nintendo_direct** tag to Humble key_type whitelist and removes extraneous **Humble Key: {key_type}** tagging, since that information is already in "Platform".
 
 # 0.1.0 Pre-release
 Release v0.1.0
@@ -57,14 +52,12 @@ Drag and drop the .pext file onto your Playnite window.
 
 Release Details
 First release implements:
-
-* Querying the Humble API for "TPKD" objects that represent game keys.
-* Checking against a key type whitelist (currently only permits steam keys)
-* Reporting the Redeemed / Unredeemed status as tags
-* Updates Redeemed / Unredeemed on previously imported games when loading the Humble Keys Library
+- Querying the Humble API for "TPKD" objects that represent game keys.
+- Checking against a key type whitelist (currently only permits steam keys)
+- Reporting the Redeemed / Unredeemed status as tags
+- Updates Redeemed / Unredeemed on previously imported games when loading the Humble Keys Library
   Creates a link to your Humble "downloads" page
 
 Upcoming features:
-
-* Other key types in the white list
-* Integrating localization
+- Other key types in the white list
+- Integrating localization

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,4 +1,4 @@
-Name: Humble Keys Importer
+Name: Humble Keys Library Importer
 Author: Dasmius007
 Id: HumbleKeysLibrary_62ac4052-e08a-4a1a-b70a-c2c0c3673bb9
 Version: 0.3.6


### PR DESCRIPTION
Restore plugin name to fix broken auto-update process in Playnite from old versions, prevent duplicate old & new plugins installed at the same time, and ensure "Already installed" button works properly in Add-on Browser

Changed * to - in changelog to conform to other Playnite plugins, as recommended by Crow