### PR TITLE
Restore plugin GUID to fix broken auto-update process

### DIFF
--- a/Manifests/HumbleKeysLibrary_Installer.yaml
+++ b/Manifests/HumbleKeysLibrary_Installer.yaml
@@ -1,11 +1,12 @@
 AddonId: 62ac4052-e08a-4a1a-b70a-c2c0c3673bb9
 Packages:
-  - Version: 0.3.7
+  - Version: 0.3.8
     RequiredApiVersion: 6.9.0
-    ReleaseDate: 2025-05-06
-    PackageUrl: https://github.com/Dasmius007/HumbleKeysLibrary/releases/download/0.3.7/HumbleKeysLibrary_0.3.7.pext
+    ReleaseDate: 2025-05-07
+    PackageUrl: https://github.com/Dasmius007/HumbleKeysLibrary/releases/download/0.3.8/HumbleKeysLibrary_0.3.8.pext
     Changelog:
-      - Restored plugin name to fix broken auto-update process from old versions, prevent duplicate old & new plugins installed at the same time, and ensure "Already installed" button works properly in Add-on Browser
+      - Restored plugin name
+      - Restored plugin GUID to fix broken auto-update process from old versions, prevent duplicate old & new plugins installed at the same time, and ensure "Already installed" button works properly in Add-on Browser
   - Version: 0.3.6
     RequiredApiVersion: 6.9.0
     ReleaseDate: 2025-05-04

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ﻿## What's Changed
-# 0.3.7
-* Restored plugin name to fix broken auto-update process from old versions, prevent duplicate old & new plugins installed at the same time, and ensure "Already installed" button works properly in Add-on Browser
+# 0.3.8
+* Restored plugin name
+* Restored plugin GUID to fix broken auto-update process from old versions, prevent duplicate old & new plugins installed at the same time, and ensure "Already installed" button works properly in Add-on Browser
 
 # 0.3.6
 * Added support for multiple languages (currently only English is implemented, but other languages can now be added)

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 Name: Humble Keys Library Importer
 Author: Dasmius007
-Id: HumbleKeysLibrary_62ac4052-e08a-4a1a-b70a-c2c0c3673bb9
-Version: 0.3.7
+Id: 62ac4052-e08a-4a1a-b70a-c2c0c3673bb9
+Version: 0.3.8
 Module: HumbleKeysLibrary.dll
 Type: GameLibrary
 Icon: icon.png


### PR DESCRIPTION
- Restored plugin GUID to fix broken auto-update process from old versions, prevent duplicate old & new plugins installed at the same time, and ensure "Already installed" button works properly in Add-on Browser
- Manually prepared HumbleKeysLibrary_Installer.yaml until GitHub Actions are updated