### PR TITLE
Update action runner version from windows-2019 to windows-2025

### DIFF
--- a/.github/workflows/generate_release_artifacts.yml
+++ b/.github/workflows/generate_release_artifacts.yml
@@ -7,7 +7,7 @@
   
   on:
     push:
-      branches: [ "releases/**" ]
+      branches: [ "releases/**", "beta/**" ]
       tags:
         - v[0-9]+.[0-9]+.[0-9]+*
   env:
@@ -80,14 +80,14 @@
           run: echo "version=${{ steps.version_tag.outputs.full }}" >> $GITHUB_OUTPUT
 
         - name: Split branch name
-          if: ${{ (github.ref_type == 'branch') && startsWith(github.ref_name,'releases/v') }}
+          if: ${{ (github.ref_type == 'branch') && (startsWith(github.ref_name,'releases/v') || startsWith(github.ref_name,'beta/v'))}}
           env:
             BRANCH: ${{ github.ref_name }}
           id: version_branch
-          run: echo "branch_version=${BRANCH:10}" >> $GITHUB_OUTPUT
+          run: echo "branch_version=${BRANCH##*/}" >> $GITHUB_OUTPUT
 
         - name: Generate version from branch
-          if: ${{ steps.version_branch.outputs.branch_version && (github.ref_type == 'branch') && startsWith(github.ref_name,'releases/v') }}
+          if: ${{ steps.version_branch.outputs.branch_version && (github.ref_type == 'branch') && (startsWith(github.ref_name,'releases/v') || startsWith(github.ref_name,'beta/v')) }}
           id: version_branch_generate
           uses: HardNorth/github-version-generate@v1.4.0
           with:
@@ -137,8 +137,8 @@
     
     build:
       #Project uses .NET Framework 4.6.2 which is not in later Github hosted runners
-      # See: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
-      runs-on: windows-2019
+      # See: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+      runs-on: windows-2025
       needs: [versioning]
       env:
         artifact-version: ${{ needs.versioning.outputs.artifact-version }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -33,8 +33,8 @@ permissions:
 jobs:
   build:
     #Project uses .NET Framework 4.6.2 which is not in later Github hosted runners
-    # See: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
-    runs-on: windows-2019
+    # See: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updated actions container from windows-2019 to windows-2025
Also allow for beta branches to trigger actions workflow